### PR TITLE
Form should use a <form> tag

### DIFF
--- a/src/collections/form.js
+++ b/src/collections/form.js
@@ -14,9 +14,9 @@ module.exports = function (React) {
       var {className, ...other} = this.props;
 
       return (
-        <div {...other} className={this.getClassName(defaultClassName)} >
+        <form {...other} className={this.getClassName(defaultClassName)} >
           {this.props.children}
-        </div>
+        </form>
       );
     }
   });


### PR DESCRIPTION
why?
1. because it's form, it make sense
2. allow using form specific behaviour like [serializeArray](https://api.jquery.com/serializeArray/)