### PR TITLE
ES6 module import error fix #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Ex. Write a simple button in browser.
 </script>
 ```
 
-### With Browserify
+### With Browserify or Webpack
 
 ```sh
 npm install react-semantify
@@ -76,7 +76,13 @@ Ex.
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-let Button = require('react-semantify').Button;
+import {Button} from 'react-semantify';
+// or
+// import * as Semantify from 'react-semantify';
+// let {Button} = Semantify;
+// or
+// use ES5
+// let Button = require('react-semantify').Button;
 
 let HelloBox = React.createClass({
 

--- a/src/collections/breadcrumb.js
+++ b/src/collections/breadcrumb.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui breadcrumb';
 
-module.exports = React.createClass({
+const Breadcrumb = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Breadcrumb;

--- a/src/collections/form.js
+++ b/src/collections/form.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui form';
 
-module.exports = React.createClass({
+const Form = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Form;

--- a/src/collections/grid.js
+++ b/src/collections/grid.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui grid';
 
-module.exports = React.createClass({
+const Grid = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Grid;

--- a/src/collections/menu.js
+++ b/src/collections/menu.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui menu';
 
-module.exports = React.createClass({
+const Menu = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Menu;

--- a/src/collections/message.js
+++ b/src/collections/message.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui message';
 
-module.exports = React.createClass({
+const Message = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Message;

--- a/src/collections/table.js
+++ b/src/collections/table.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui table';
 
-module.exports = React.createClass({
+const Table = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Table;

--- a/src/commons/column.js
+++ b/src/commons/column.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'column';
 
-module.exports = React.createClass({
+const Column = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Column;

--- a/src/commons/content.js
+++ b/src/commons/content.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from './unit';
+import {Unit} from './unit';
 
 let defaultClassName = 'content';
 

--- a/src/commons/content.js
+++ b/src/commons/content.js
@@ -5,7 +5,7 @@ import Unit from './unit';
 
 let defaultClassName = 'content';
 
-module.exports = React.createClass({
+const Content = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Content;

--- a/src/commons/field.js
+++ b/src/commons/field.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'field';
 
-module.exports = React.createClass({
+const Field = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Field;

--- a/src/commons/fields.js
+++ b/src/commons/fields.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'fields';
 
-module.exports = React.createClass({
+const Fields = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Fields;

--- a/src/commons/row.js
+++ b/src/commons/row.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'row';
 
-module.exports = React.createClass({
+const Row = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Row;

--- a/src/commons/section.js
+++ b/src/commons/section.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import TypeSelector from '../mixins/typeSelector';
-import Unit from './unit';
+import {Unit} from './unit';
 
 let defaultClassName = 'section';
 

--- a/src/commons/section.js
+++ b/src/commons/section.js
@@ -6,7 +6,7 @@ import Unit from './unit';
 
 let defaultClassName = 'section';
 
-module.exports = React.createClass({
+const Section = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, TypeSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Section;

--- a/src/commons/text.js
+++ b/src/commons/text.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'text';
 
-module.exports = React.createClass({
+const Text = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Text;

--- a/src/commons/title.js
+++ b/src/commons/title.js
@@ -5,7 +5,7 @@ import Unit from './unit';
 
 let defaultClassName = 'title';
 
-module.exports = React.createClass({
+const Title = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Title;

--- a/src/commons/title.js
+++ b/src/commons/title.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from './unit';
+import {Unit} from './unit';
 
 let defaultClassName = 'title';
 

--- a/src/commons/unit.js
+++ b/src/commons/unit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classSet from 'classnames';
 
-module.exports = React.createClass({
+export default React.createClass({
 
   propTypes: {
     className: React.PropTypes.string.isRequired,

--- a/src/commons/unit.js
+++ b/src/commons/unit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classSet from 'classnames';
 
-export default React.createClass({
+export const Unit = React.createClass({
 
   propTypes: {
     className: React.PropTypes.string.isRequired,

--- a/src/elements/button.js
+++ b/src/elements/button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui button';
 

--- a/src/elements/button.js
+++ b/src/elements/button.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui button';
 
-module.exports = React.createClass({
+const Button = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, StateSelector],
 
@@ -27,3 +27,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Button;

--- a/src/elements/divider.js
+++ b/src/elements/divider.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui divider';
 
-module.exports = React.createClass({
+const Divider = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -15,3 +15,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Divider;

--- a/src/elements/flag.js
+++ b/src/elements/flag.js
@@ -4,7 +4,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'flag';
 
-module.exports = React.createClass({
+const Flag = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -21,3 +21,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Flag;

--- a/src/elements/flag.js
+++ b/src/elements/flag.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'flag';
 

--- a/src/elements/header.js
+++ b/src/elements/header.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import TypeSelector from '../mixins/typeSelector';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui header';
 

--- a/src/elements/header.js
+++ b/src/elements/header.js
@@ -7,7 +7,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui header';
 
-module.exports = React.createClass({
+const Header = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, TypeSelector, StateSelector],
 
@@ -26,3 +26,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Header;

--- a/src/elements/icon.js
+++ b/src/elements/icon.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'icon';
 
-module.exports = React.createClass({
+const Icon = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, StateSelector],
 
@@ -25,3 +25,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Icon;

--- a/src/elements/icon.js
+++ b/src/elements/icon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'icon';
 

--- a/src/elements/image.js
+++ b/src/elements/image.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui image';
 
-module.exports = React.createClass({
+const Image = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Image;

--- a/src/elements/image.js
+++ b/src/elements/image.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui image';
 

--- a/src/elements/input.js
+++ b/src/elements/input.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui input';
 
-module.exports = React.createClass({
+const Input = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -43,3 +43,5 @@ module.exports = React.createClass({
 
   }
 });
+
+export default Input;

--- a/src/elements/input.js
+++ b/src/elements/input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui input';
 

--- a/src/elements/label.js
+++ b/src/elements/label.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import TypeSelector from '../mixins/typeSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui label';
 

--- a/src/elements/label.js
+++ b/src/elements/label.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui label';
 
-module.exports = React.createClass({
+const Label = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, TypeSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Label;

--- a/src/elements/list.js
+++ b/src/elements/list.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui list';
 
-module.exports = React.createClass({
+const List = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default List;

--- a/src/elements/loader.js
+++ b/src/elements/loader.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui loader';
 
-module.exports = React.createClass({
+const Loader = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -25,3 +25,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Loader;

--- a/src/elements/loader.js
+++ b/src/elements/loader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui loader';
 

--- a/src/elements/rail.js
+++ b/src/elements/rail.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui rail';
 
-module.exports = React.createClass({
+const Rail = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Rail;

--- a/src/elements/reveal.js
+++ b/src/elements/reveal.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui reveal';
 
-module.exports = React.createClass({
+const Reveal = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Reveal;

--- a/src/elements/reveal.js
+++ b/src/elements/reveal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui reveal';
 

--- a/src/elements/segment.js
+++ b/src/elements/segment.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui segment';
 
-module.exports = React.createClass({
+const Segment = React.createClass({
 
   mixins: [ClassGenerator, ColorSelector, StateSelector],
 
@@ -25,3 +25,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Segment;

--- a/src/elements/segment.js
+++ b/src/elements/segment.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import ColorSelector from '../mixins/colorSelector';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui segment';
 

--- a/src/elements/step.js
+++ b/src/elements/step.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'step';
 

--- a/src/elements/step.js
+++ b/src/elements/step.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'step';
 
-module.exports = React.createClass({
+const Step = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -26,3 +26,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Step;

--- a/src/elements/steps.js
+++ b/src/elements/steps.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui steps';
 
-module.exports = React.createClass({
+const Steps = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Steps;

--- a/src/index.js
+++ b/src/index.js
@@ -1,63 +1,60 @@
-import React from 'react';
 
-module.exports = {
-  // collections
-  Breadcrumb: require('./collections/breadcrumb.js'),
-  Form: require('./collections/form.js'),
-  Grid: require('./collections/grid.js'),
-  Menu: require('./collections/menu.js'),
-  Message: require('./collections/message.js'),
-  Table: require('./collections/table.js'),
+// collections
+export Breadcrumb from './collections/breadcrumb';
+export Form from './collections/form';
+export Grid from './collections/grid';
+export Menu from './collections/menu';
+export Message from './collections/message';
+export Table from './collections/table';
 
-  // commons
-  Column: require('./commons/column.js'),
-  Content: require('./commons/content.js'),
-  Field: require('./commons/field.js'),
-  Fields: require('./commons/fields.js'),
-  Row: require('./commons/row.js'),
-  Section: require('./commons/section.js'),
-  Text: require('./commons/text.js'),
-  Title: require('./commons/title.js'),
+// commons
+export Column from './commons/column';
+export Content from './commons/content';
+export Field from './commons/field';
+export Fields from './commons/fields';
+export Row from './commons/row';
+export Section from './commons/section';
+export Text from './commons/text';
+export Title from './commons/title';
 
-  // elements
-  Button: require('./elements/button.js'),
-  Divider: require('./elements/divider.js'),
-  Flag: require('./elements/flag.js'),
-  Header: require('./elements/header.js'),
-  Icon: require('./elements/icon.js'),
-  Image: require('./elements/image.js'),
-  Input: require('./elements/input.js'),
-  Label: require('./elements/label.js'),
-  List: require('./elements/list.js'),
-  Loader: require('./elements/loader.js'),
-  Rail: require('./elements/rail.js'),
-  Reveal: require('./elements/reveal.js'),
-  Segment: require('./elements/segment.js'),
-  Step: require('./elements/step.js'),
-  Steps: require('./elements/steps.js'),
+// elements
+export Button from './elements/button';
+export Divider from './elements/divider';
+export Flag from './elements/flag';
+export Header from './elements/header';
+export Icon from './elements/icon';
+export Image from './elements/image';
+export Input from './elements/input';
+export Label from './elements/label';
+export List from './elements/list';
+export Loader from './elements/loader';
+export Rail from './elements/rail';
+export Reveal from './elements/reveal';
+export Segment from './elements/segment';
+export Step from './elements/step';
+export Steps from './elements/steps';
 
-  // modules
-  Accordion: require('./modules/accordion.js'),
-  Checkbox: require('./modules/checkbox.js'),
-  Dimmer: require('./modules/dimmer.js'),
-  Dropdown: require('./modules/dropdown.js'),
-  Modal: require('./modules/modal.js'),
-  Popup: require('./modules/popup.js'),
-  Progress: require('./modules/progress.js'),
-  Rating: require('./modules/rating.js'),
-  Search: require('./modules/search.js'),
-  Shape: require('./modules/shape.js'),
-  Sidebar: require('./modules/sidebar.js'),
-  Sticky: require('./modules/sticky.js'),
-  Tab: require('./modules/tab.js'),
+// modules
+export Accordion from './modules/accordion';
+export Checkbox from './modules/checkbox';
+export Dimmer from './modules/dimmer';
+export Dropdown from './modules/dropdown';
+export Modal from './modules/modal';
+export Popup from './modules/popup';
+export Progress from './modules/progress';
+export Rating from './modules/rating';
+export Search from './modules/search';
+export Shape from './modules/shape';
+export Sidebar from './modules/sidebar';
+export Sticky from './modules/sticky';
+export Tab from './modules/tab';
 
-  // views
-  Ad: require('./views/advertisement.js'),
-  Card: require('./views/card.js'),
-  Comment: require('./views/comment.js'),
-  Comments: require('./views/comments.js'),
-  Feed: require('./views/feed.js'),
-  Item: require('./views/item.js'),
-  Items: require('./views/items.js'),
-  Statistic: require('./views/statistic.js')
-};
+// views
+export Ad from './views/advertisement';
+export Card from './views/card';
+export Comment from './views/comment';
+export Comments from './views/comments';
+export Feed from './views/feed';
+export Item from './views/item';
+export Items from './views/items';
+export Statistic from './views/statistic';

--- a/src/mixins/classGenerator.js
+++ b/src/mixins/classGenerator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classSet from 'classnames';
 
-module.exports = {
+export default {
 
   propTypes: {
     className: React.PropTypes.string

--- a/src/mixins/colorSelector.js
+++ b/src/mixins/colorSelector.js
@@ -5,7 +5,7 @@ let colorArray = [
   'orange', 'purple', 'red', 'teal'
 ];
 
-module.exports = {
+export default {
 
   propTypes: {
     color: React.PropTypes.oneOf(colorArray)

--- a/src/mixins/stateSelector.js
+++ b/src/mixins/stateSelector.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-module.exports = {
+export default {
 
   propTypes: {
     disabled: React.PropTypes.bool,

--- a/src/mixins/typeSelector.js
+++ b/src/mixins/typeSelector.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 let typeArray = ['div', 'link', 'icon'];
 
-module.exports =  {
+export default  {
 
   propTypes: {
     type: React.PropTypes.oneOf(typeArray)

--- a/src/modules/accordion.js
+++ b/src/modules/accordion.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui accordion';
 
-module.exports = React.createClass({
+const Accordion = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -29,3 +29,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Accordion;

--- a/src/modules/checkbox.js
+++ b/src/modules/checkbox.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui checkbox';
 
-module.exports = React.createClass({
+const Checkbox = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -40,3 +40,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Checkbox;

--- a/src/modules/checkbox.js
+++ b/src/modules/checkbox.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui checkbox';
 

--- a/src/modules/dimmer.js
+++ b/src/modules/dimmer.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui dimmer';
 
-module.exports = React.createClass({
+const Dimmer = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -40,3 +40,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Dimmer;

--- a/src/modules/dimmer.js
+++ b/src/modules/dimmer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui dimmer';
 

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui dropdown';
 

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui dropdown';
 
-module.exports = React.createClass({
+const Dropdown = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -45,3 +45,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Dropdown;

--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui modal';
 

--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui modal';
 
-module.exports = React.createClass({
+const Modal = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -39,3 +39,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Modal;

--- a/src/modules/popup.js
+++ b/src/modules/popup.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui popup';
 
-module.exports = React.createClass({
+const Popup = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -15,3 +15,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Popup;

--- a/src/modules/progress.js
+++ b/src/modules/progress.js
@@ -4,7 +4,7 @@ import StateSelector from '../mixins/stateSelector';
 
 let defaultClassName = 'ui progress';
 
-module.exports = React.createClass({
+const Progress = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -51,3 +51,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Progress;

--- a/src/modules/rating.js
+++ b/src/modules/rating.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui rating';
 
-module.exports = React.createClass({
+const Rating = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -36,3 +36,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Rating;

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -6,7 +6,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'ui search';
 
-module.exports = React.createClass({
+const Search = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -39,3 +39,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Search;

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassGenerator from '../mixins/classGenerator';
 import StateSelector from '../mixins/stateSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'ui search';
 

--- a/src/modules/shape.js
+++ b/src/modules/shape.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui shape';
 
-module.exports = React.createClass({
+const Shap = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -32,3 +32,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Shap;

--- a/src/modules/sidebar.js
+++ b/src/modules/sidebar.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui sidebar';
 
-module.exports = React.createClass({
+const Sidebar = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -32,3 +32,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Sidebar;

--- a/src/modules/sticky.js
+++ b/src/modules/sticky.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui sticky';
 
-module.exports = React.createClass({
+const Sticky = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -32,3 +32,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Sticky;

--- a/src/modules/tab.js
+++ b/src/modules/tab.js
@@ -4,7 +4,7 @@ import StateSelector from '../mixins/stateSelector';
 
 let defaultClassName = 'ui tab';
 
-module.exports = React.createClass({
+const Tab = React.createClass({
 
   mixins: [ClassGenerator, StateSelector],
 
@@ -41,3 +41,5 @@ module.exports = React.createClass({
     }
   }
 });
+
+export default Tab;

--- a/src/views/advertisement.js
+++ b/src/views/advertisement.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui ad';
 
-module.exports = React.createClass({
+const Ad = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Ad;

--- a/src/views/card.js
+++ b/src/views/card.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui card';
 
-module.exports = React.createClass({
+const Card = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Card;

--- a/src/views/comment.js
+++ b/src/views/comment.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'comment';
 
-module.exports = React.createClass({
+const Comment = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Comment;

--- a/src/views/comments.js
+++ b/src/views/comments.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui comments';
 
-module.exports = React.createClass({
+const Comments = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Comments;

--- a/src/views/feed.js
+++ b/src/views/feed.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui feed';
 
-module.exports = React.createClass({
+const Feed = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Feed;

--- a/src/views/item.js
+++ b/src/views/item.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassGenerator from '../mixins/classGenerator';
 import TypeSelector from '../mixins/typeSelector';
-import Unit from '../commons/unit';
+import {Unit} from '../commons/unit';
 
 let defaultClassName = 'item';
 

--- a/src/views/item.js
+++ b/src/views/item.js
@@ -5,7 +5,7 @@ import Unit from '../commons/unit';
 
 let defaultClassName = 'item';
 
-module.exports = React.createClass({
+const Item = React.createClass({
 
   mixins: [ClassGenerator, TypeSelector],
 
@@ -24,3 +24,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Item;

--- a/src/views/items.js
+++ b/src/views/items.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui items';
 
-module.exports = React.createClass({
+const Items = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -28,3 +28,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Items;

--- a/src/views/statistic.js
+++ b/src/views/statistic.js
@@ -3,7 +3,7 @@ import ClassGenerator from '../mixins/classGenerator';
 
 let defaultClassName = 'ui statistic';
 
-module.exports = React.createClass({
+const Statistic = React.createClass({
 
   mixins: [ClassGenerator],
 
@@ -18,3 +18,5 @@ module.exports = React.createClass({
     );
   }
 });
+
+export default Statistic

--- a/test/__tests__/commons/Unit-test.js
+++ b/test/__tests__/commons/Unit-test.js
@@ -5,7 +5,7 @@ jest.dontMock('../../../src/commons/unit.js');
 let ReactDOM  = require('react-dom');
 let React     = require('react');
 let TestUtils = require('react-addons-test-utils');
-var Unit      = require('../../../src/commons/unit.js');
+var Unit      = require('../../../src/commons/unit.js').Unit;
 
 describe('Unit', function () {
   it('should have child by default', function () {


### PR DESCRIPTION
Support ES6 export and import. Relative #14 

Now could use like
```js
import {Button} from 'react-semantify';
```
or
```js
import * as Semantify from 'react-semantify';
let {Button} = Semantify;
```
or es5
```js
var Button = require('react-semantify').Button;
```
Not support:
```js
import Semantify from 'react-semantify';
let {Button} = Semantify;
```